### PR TITLE
Improve Tiptap editors and add admin delete routes

### DIFF
--- a/src/app/api/posts/[postId]/comments/[commentId]/route.ts
+++ b/src/app/api/posts/[postId]/comments/[commentId]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { withAuth, AuthenticatedRequest } from '@/lib/withAuth';
+import { query } from '@/lib/db';
+
+interface CommentDeleteParams {
+  params: {
+    postId: string;
+    commentId: string;
+  };
+}
+
+async function deleteCommentHandler(req: AuthenticatedRequest, context: CommentDeleteParams) {
+  const commentId = parseInt(context.params.commentId, 10);
+  if (isNaN(commentId)) {
+    return NextResponse.json({ error: 'Invalid comment ID' }, { status: 400 });
+  }
+
+  try {
+    await query('DELETE FROM comments WHERE id = $1', [commentId]);
+    return NextResponse.json({ message: 'Comment deleted' });
+  } catch (error) {
+    console.error(`[API] Error deleting comment ${commentId}:`, error);
+    return NextResponse.json({ error: 'Failed to delete comment' }, { status: 500 });
+  }
+}
+
+export const DELETE = withAuth(deleteCommentHandler, true);

--- a/src/app/api/posts/[postId]/route.ts
+++ b/src/app/api/posts/[postId]/route.ts
@@ -26,4 +26,20 @@ async function getSinglePostHandler(req: AuthenticatedRequest, context: SinglePo
 
 export const GET = withAuth(getSinglePostHandler, false);
 
-// Future: Add PUT/DELETE handlers here for post management if needed, protected by withAuth 
+// DELETE a post (admin only)
+async function deletePostHandler(req: AuthenticatedRequest, context: SinglePostParams) {
+  const postId = parseInt(context.params.postId, 10);
+  if (isNaN(postId)) {
+    return NextResponse.json({ error: 'Invalid post ID' }, { status: 400 });
+  }
+
+  try {
+    await query('DELETE FROM posts WHERE id = $1', [postId]);
+    return NextResponse.json({ message: 'Post deleted' });
+  } catch (error) {
+    console.error(`[API] Error deleting post ${postId}:`, error);
+    return NextResponse.json({ error: 'Failed to delete post' }, { status: 500 });
+  }
+}
+
+export const DELETE = withAuth(deletePostHandler, true);

--- a/src/components/voting/NewCommentForm.tsx
+++ b/src/components/voting/NewCommentForm.tsx
@@ -11,7 +11,7 @@ import { EditorToolbar } from './EditorToolbar';
 
 import { useEditor, EditorContent, Editor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
-import { Markdown } from 'tiptap-markdown';
+import { Markdown, markdownToTiptap } from 'tiptap-markdown';
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
 import { common, createLowlight } from 'lowlight';
 
@@ -87,6 +87,22 @@ export const NewCommentForm: React.FC<NewCommentFormProps> = ({
     editorProps: {
       attributes: {
         class: 'prose prose-sm dark:prose-invert leading-snug focus:outline-none min-h-[80px] border border-input rounded-md px-3 py-2 w-full',
+      },
+      handlePaste(view, event) {
+        const text = event.clipboardData?.getData('text/plain');
+        if (text) {
+          try {
+            const json = markdownToTiptap(text, editor?.extensionManager.extensions || []);
+            if (json) {
+              editor?.commands.insertContent(json);
+              event.preventDefault();
+              return true;
+            }
+          } catch (e) {
+            console.warn('Failed to parse pasted markdown', e);
+          }
+        }
+        return false;
       },
     },
   });

--- a/src/components/voting/NewPostForm.tsx
+++ b/src/components/voting/NewPostForm.tsx
@@ -15,7 +15,7 @@ import Link from 'next/link';
 // Tiptap imports
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
-import { Markdown } from 'tiptap-markdown'; 
+import { Markdown, markdownToTiptap } from 'tiptap-markdown';
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
 import { common, createLowlight } from 'lowlight';
 import Placeholder from '@tiptap/extension-placeholder';
@@ -100,8 +100,8 @@ export const NewPostForm: React.FC<NewPostFormProps> = ({ onPostCreated }) => {
       Image, 
       // Explicitly use CodeBlockLowlight for its input rules and syntax highlighting
       CodeBlockLowlight.configure({ lowlight }),
-      // Markdown extension for parsing pasted Markdown and potentially serializing
-      // Markdown.configure({ html: false, tightLists: true }), // Temporarily commented out for testing input rules
+      // Markdown extension for parsing pasted Markdown
+      Markdown.configure({ html: false, tightLists: true }),
       // Utility extensions
       Placeholder.configure({
         placeholder: 'Describe your post in detail (Markdown supported!)...',
@@ -112,6 +112,22 @@ export const NewPostForm: React.FC<NewPostFormProps> = ({ onPostCreated }) => {
     editorProps: {
       attributes: {
         class: 'prose prose-sm dark:prose-invert leading-snug focus:outline-none min-h-[150px] border border-input rounded-md px-3 py-2 w-full',
+      },
+      handlePaste(view, event) {
+        const text = event.clipboardData?.getData('text/plain');
+        if (text) {
+          try {
+            const json = markdownToTiptap(text, contentEditor?.extensionManager.extensions || []);
+            if (json) {
+              contentEditor?.commands.insertContent(json);
+              event.preventDefault();
+              return true;
+            }
+          } catch (e) {
+            console.warn('Failed to parse pasted markdown', e);
+          }
+        }
+        return false;
       },
     },
   });


### PR DESCRIPTION
## Summary
- support Markdown paste in post & comment editors
- replace prompt-based toolbar actions with inline inputs
- add delete API routes for posts and comments
- allow admins to delete posts and comments from the UI

## Testing
- `yarn lint` *(fails: package not in lockfile)*